### PR TITLE
Fix test by using waitFor

### DIFF
--- a/src/test/example.test.tsx
+++ b/src/test/example.test.tsx
@@ -38,8 +38,8 @@ describe('useSectionDisplayRules', () => {
   });
 
   describe('loading', () => {
-    it('cannot show any sections until loading is complete', () => {
-      const { result } = renderHook(() => useSectionDisplayRules());
+    it('cannot show any sections until loading is complete', async () => {
+      const { result, waitFor } = renderHook(() => useSectionDisplayRules());
 
       expect(result.current.loading).toBe(true);
       expect(result.current.canShow(sectionName)).toBe(false);
@@ -48,7 +48,18 @@ describe('useSectionDisplayRules', () => {
         fetchComplete();
       });
 
-      expect(result.current.loading).toBe(false);
+      // Promise resolution from `fetchComplete` happens asynchronously. We can
+      // either wait until the next process tick and _then_ do our assertions
+      // OR we can use `waitFor` (https://www.npmjs.com/package/wait-for-expect
+      // wrapped in `act` and re-exported by testing-library) to try the
+      // assertion a few times over the course of a couple process ticks.
+      // Wherever possible (and it's not always possible), I think it's best to
+      // prefer `waitFor` over explicit `setTimeout` calls, to make the test as
+      // ignorant as possible of the internals of the implementation.
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      })
+
       expect(result.current.canShow(sectionName)).toBe(true);
     });
   });


### PR DESCRIPTION
The code comment attempts to explain this. Feel free to reach out with any questions. `act` warnings in tests can be super frustrating and hard to squash.